### PR TITLE
Added get Long option to JSONObject and JSONArray

### DIFF
--- a/src/merrimackutil/json/types/JSONArray.java
+++ b/src/merrimackutil/json/types/JSONArray.java
@@ -98,6 +98,21 @@ public final class JSONArray extends ArrayList<Object> implements JSONType
   }
 
   /**
+   * Gets long associated with the idx. If the
+   * idx is not associated with a Long, null is
+   * returned.
+   * @param idx the idx to find the associated value of.
+   * @return the associated value or null.
+   */
+  public Long getLong(int idx) {
+      Object val = get(idx);
+
+      if (val instanceof Long)
+          return (Long) val;
+      return null;
+  }
+
+  /**
    * Gets Boolean associated with the idx. If the
    * idx is not associated with a Boolean, null is
    * returned.

--- a/src/merrimackutil/json/types/JSONObject.java
+++ b/src/merrimackutil/json/types/JSONObject.java
@@ -101,6 +101,22 @@ public final class JSONObject extends HashMap<String, Object> implements JSONTyp
   }
 
   /**
+   * Gets long associated with the key. If the
+   * key is not associated with a Long, null is
+   * returned.
+   * @param key the key to find the associated value of.
+   * @return the associated value or null.
+   */
+  public Long getLong(String key)
+  {
+      Object val = get(key);
+
+      if (val instanceof Long)
+          return (Long) val;
+      return null;
+  }
+
+  /**
    * Gets Boolean associated with the key. If the
    * key is not associated with a Boolean, null is
    * returned.


### PR DESCRIPTION
Added get long option to JSONObject and JSONArray. This was motivated by Project 3 in Network Security(CSC3055), the "Ticket" JSON object has a field "creation-time" which has a long value(epoch time). This method would be convenient to use in that case. 