### PR TITLE
FIxed get Long returning null after JSON was parsed 

### DIFF
--- a/src/merrimackutil/json/types/JSONObject.java
+++ b/src/merrimackutil/json/types/JSONObject.java
@@ -16,13 +16,14 @@
  */
 package merrimackutil.json.types;
 
+import merrimackutil.json.lexer.Lexer;
+import merrimackutil.json.lexer.Token;
+import merrimackutil.json.lexer.TokenType;
+
 import java.io.InvalidObjectException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import merrimackutil.json.lexer.Lexer;
-import merrimackutil.json.lexer.Token;
-import merrimackutil.json.lexer.TokenType;
 
 /**
  * This class represents a JSON object.
@@ -111,8 +112,14 @@ public final class JSONObject extends HashMap<String, Object> implements JSONTyp
   {
       Object val = get(key);
 
-      if (val instanceof Long)
+      if (val instanceof Long) {
           return (Long) val;
+      }
+      else if (val instanceof Double) {
+          if (Math.floor((Double)val) == (Double) val)
+              return (((Double) val).longValue());
+      }
+
       return null;
   }
 


### PR DESCRIPTION
Parser seems to read number as doubles, so when parsed with JsonIO it will always be double type, so we will check if long is a double without a decimal value before returning it.

We still check if the type is a Long to avoid the following case returning null. 
```java
JSONObject jsonobject = new JSONObject;
Long longVal = System.currentTimeMillis();
jsonobject.put("longVal", longVal);

jsonobject.getLong("longVal");  //will return null if we do not check if type is Long and return it 
```