### PR TITLE
Removed old print statement in Base32 decoder 

### DIFF
--- a/src/merrimackutil/codec/Base32.java
+++ b/src/merrimackutil/codec/Base32.java
@@ -93,8 +93,6 @@ package merrimackutil.codec;
           b32Tbl.indexOf(String.valueOf(b32str.charAt(i))))).replace(" ", "0");
      }
 
-    System.out.println(binString);
-
     res = new byte[binString.length()/8];
     for (int i = 0; i < binString.length()/8; i++)
       res[i] = (byte) (Integer.parseInt(


### PR DESCRIPTION
Motivated by Project 4 in Network Security, when using Base32.decode() it would printout the binary raw binary string. 

Example code output with static analysis. 
![image](https://github.com/user-attachments/assets/9bd6ac08-07e3-46e3-ac6b-e2b89fb0ba7b)

(Note for Kissel's sanity we switched over to the Base64 decoder for this part of the project to meet the spec) 
